### PR TITLE
test: add smoke test for CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,4 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn lint
       - run: yarn test
+      - run: bash ./bin/smoke-test.sh

--- a/bin/smoke-test.sh
+++ b/bin/smoke-test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Smoke test to ensure that the CLI actually works as a CLI. Otherwise, it might run in Jest but fail
+# when executed from Node (e.g. because of a missing ".js" in an import, which is required for ESM).
+
+set -e
+set -x
+
+for TRANSFORM in $(ls ./tests/fixtures); do
+  for DIR in $(ls "tests/fixtures/${TRANSFORM}"); do
+    mkdir -p "/tmp/lwc-codemod-tests/${TRANSFORM}"
+    cp -R "./tests/fixtures/${TRANSFORM}/${DIR}" "/tmp/lwc-codemod-tests/${TRANSFORM}/${DIR}"
+
+    node ./transforms/cli.js "${TRANSFORM}" "/tmp/lwc-codemod-tests/${TRANSFORM}/${DIR}"
+  done
+done
+
+rm -fr /tmp/lwc-codemod-tests


### PR DESCRIPTION
This adds a smoke test as described [here](https://github.com/salesforce/lwc-codemod/pull/16#issuecomment-1636386985). This is mostly just to make sure we don't forget to add `.js` to ESM imports. I verified that the smoke test will fail in that case.