### PR TITLE
fix: update to latest mixed mode spec

### DIFF
--- a/tests/fixtures/synthetic-to-native/no-prop/expected/x/component/component.js
+++ b/tests/fixtures/synthetic-to-native/no-prop/expected/x/component/component.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc'
 
 export default class extends LightningElement {
-  static shadowSupportMode = "any";
+  static shadowSupportMode = "native";
 }

--- a/tests/fixtures/synthetic-to-native/prop-already-correct/expected/x/component/component.js
+++ b/tests/fixtures/synthetic-to-native/prop-already-correct/expected/x/component/component.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc'
 
 export default class extends LightningElement {
-  static shadowSupportMode = 'any'
+  static shadowSupportMode = 'native'
 }

--- a/tests/fixtures/synthetic-to-native/prop-already-correct/input/x/component/component.js
+++ b/tests/fixtures/synthetic-to-native/prop-already-correct/input/x/component/component.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc'
 
 export default class extends LightningElement {
-  static shadowSupportMode = 'any'
+  static shadowSupportMode = 'native'
 }

--- a/tests/fixtures/synthetic-to-native/prop-already-exists/expected/x/component/component.js
+++ b/tests/fixtures/synthetic-to-native/prop-already-exists/expected/x/component/component.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc'
 
 export default class extends LightningElement {
-  static shadowSupportMode = "any"
+  static shadowSupportMode = "native"
 }

--- a/transforms/syntheticToNative/index.js
+++ b/transforms/syntheticToNative/index.js
@@ -11,7 +11,7 @@ export const syntheticToNative = async ({ component }) => {
     overwrite: {},
     delete: []
   }
-  const modified = replaceOrInsertStaticProperty(component.ast, 'shadowSupportMode', 'any')
+  const modified = replaceOrInsertStaticProperty(component.ast, 'shadowSupportMode', 'native')
   if (modified) {
     result.overwrite[component.file] = component.ast.toSource()
   }


### PR DESCRIPTION
Mixed mode now uses `'native'` rather than `'any'`: https://developer.salesforce.com/blogs/2024/01/get-your-lwc-components-ready-native-shadow-dom