### PR TITLE
fix(shadow-to-light): correctly transform imported .css

### DIFF
--- a/bin/smoke-test.sh
+++ b/bin/smoke-test.sh
@@ -11,7 +11,12 @@ for TRANSFORM in $(ls ./tests/fixtures); do
     mkdir -p "/tmp/lwc-codemod-tests/${TRANSFORM}"
     cp -R "./tests/fixtures/${TRANSFORM}/${DIR}" "/tmp/lwc-codemod-tests/${TRANSFORM}/${DIR}"
 
-    node ./transforms/cli.js "${TRANSFORM}" "/tmp/lwc-codemod-tests/${TRANSFORM}/${DIR}"
+    CLI_PATH="$(pwd)/transforms/cli.js"
+
+    # intentionally test with a relative file path since that's what most users will do
+    cd /tmp/lwc-codemod-tests
+    node "$CLI_PATH" "${TRANSFORM}" "${TRANSFORM}/${DIR}"
+    cd -
   done
 done
 

--- a/tests/fixtures/shadow-to-light/css-imported-from-js/expected/logs.json
+++ b/tests/fixtures/shadow-to-light/css-imported-from-js/expected/logs.json
@@ -1,0 +1,15 @@
+{
+  "modified": [
+    "x/component/component.js",
+    "x/component/component.html",
+    "x/component/component.scoped.css"
+  ],
+  "deleted": [
+    "x/component/component.css"
+  ],
+  "errors": [],
+  "total": {
+    "numModified": 4,
+    "numErrors": 0
+  }
+}

--- a/tests/fixtures/shadow-to-light/css-imported-from-js/expected/x/component/component.html
+++ b/tests/fixtures/shadow-to-light/css-imported-from-js/expected/x/component/component.html
@@ -1,0 +1,2 @@
+<template lwc:render-mode="light">
+</template>

--- a/tests/fixtures/shadow-to-light/css-imported-from-js/expected/x/component/component.js
+++ b/tests/fixtures/shadow-to-light/css-imported-from-js/expected/x/component/component.js
@@ -1,0 +1,12 @@
+import { LightningElement } from 'lwc'
+
+import template from './component.html';
+import stylesheet from "./component.scoped.css";
+
+// just use it so that ESLint doesn't complain
+console.log(template)
+console.log(stylesheet)
+
+export default class extends LightningElement {
+  static renderMode = "light";
+}

--- a/tests/fixtures/shadow-to-light/css-imported-from-js/expected/x/component/component.scoped.css
+++ b/tests/fixtures/shadow-to-light/css-imported-from-js/expected/x/component/component.scoped.css
@@ -1,0 +1,3 @@
+div {
+    color: blue;
+}

--- a/tests/fixtures/shadow-to-light/css-imported-from-js/input/x/component/component.css
+++ b/tests/fixtures/shadow-to-light/css-imported-from-js/input/x/component/component.css
@@ -1,0 +1,3 @@
+div {
+    color: blue;
+}

--- a/tests/fixtures/shadow-to-light/css-imported-from-js/input/x/component/component.html
+++ b/tests/fixtures/shadow-to-light/css-imported-from-js/input/x/component/component.html
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/tests/fixtures/shadow-to-light/css-imported-from-js/input/x/component/component.js
+++ b/tests/fixtures/shadow-to-light/css-imported-from-js/input/x/component/component.js
@@ -1,0 +1,11 @@
+import { LightningElement } from 'lwc'
+
+import template from './component.html';
+import stylesheet from './component.css'
+
+// just use it so that ESLint doesn't complain
+console.log(template)
+console.log(stylesheet)
+
+export default class extends LightningElement {
+}

--- a/transforms/jsUtils.js
+++ b/transforms/jsUtils.js
@@ -39,3 +39,17 @@ export function replaceOrInsertStaticProperty (ast, name, value, typeAnnotation 
   })
   return modified
 }
+
+// Make an array unique via some function that returns the unique key for a given array item
+export function uniqBy (array, keyGenerator) {
+  const set = new Set()
+  const result = []
+  for (const item of array) {
+    const key = keyGenerator(item)
+    if (!set.has(key)) {
+      set.add(key)
+      result.push(item)
+    }
+  }
+  return result
+}

--- a/transforms/runTransform.js
+++ b/transforms/runTransform.js
@@ -22,7 +22,7 @@ const transforms = {
   'html-template-cleanup': htmlTemplateCleanup
 }
 
-function uniqByAbsPath(filePaths) {
+function uniqByAbsPath (filePaths) {
   const set = new Set()
   for (const filePath of filePaths) {
     set.add(path.resolve(filePath))

--- a/transforms/runTransform.js
+++ b/transforms/runTransform.js
@@ -7,7 +7,6 @@
 import { isDirectory } from './fsUtils.js'
 import { observer } from './observer.js'
 import fs from 'fs/promises'
-import path from 'path'
 import { walkComponents } from './walkComponents.js'
 import { shadowToLight } from './shadowToLight/index.js'
 import { syntheticToNative } from './syntheticToNative/index.js'
@@ -20,14 +19,6 @@ const transforms = {
   'shadow-to-light': shadowToLight,
   'synthetic-to-native': syntheticToNative,
   'html-template-cleanup': htmlTemplateCleanup
-}
-
-function uniqByAbsPath (filePaths) {
-  const set = new Set()
-  for (const filePath of filePaths) {
-    set.add(path.resolve(filePath))
-  }
-  return [...set]
 }
 
 export async function runTransform (dir, transformPath) {
@@ -68,10 +59,7 @@ export async function runTransform (dir, transformPath) {
       for (const [file, content] of Object.entries(result.overwrite)) {
         await writeFile(file, content)
       }
-      // TODO: this is a hacky solution to the problem - it would be better to avoid running duplicate transforms
-      // in the first place. But this is a simple solution to the problem of trying to delete the same file twice
-      // because one is a relative path and the other is an absolute path.
-      for (const file of uniqByAbsPath(result.delete)) {
+      for (const file of result.delete) {
         await deleteFile(file)
       }
     }

--- a/transforms/shadowToLight/modifyComponentJavaScript.js
+++ b/transforms/shadowToLight/modifyComponentJavaScript.js
@@ -78,13 +78,13 @@ function replaceImportsOfCss (ast) {
     .forEach(path => {
       const { value: { source } } = path
       if (source.type === 'Literal' && source.value.endsWith('.css') && !source.value.endsWith('.scoped.css')) {
-      j(path).replaceWith(
-      j.importDeclaration(
-        path.node.specifiers,
-        j.stringLiteral(source.value.replace(/\.css$/, '.scoped.css'))
-      ))
+        j(path).replaceWith(
+          j.importDeclaration(
+            path.node.specifiers,
+            j.stringLiteral(source.value.replace(/\.css$/, '.scoped.css'))
+          ))
       }
-  })
+    })
 }
 
 export function modifyComponentJavaScript (jsFile, source, ast, result) {


### PR DESCRIPTION
This fixes #25 (error when trying to delete the same `.css` file more than once) as well as fixing an additional issue, which is that `shadow-to-light` was not properly transforming:

```js
import sheet from './sheet.css'
```

to

```js
import sheet from './sheet.scoped.css'
```

There is an additional issue where we don't handle `import stylesheet from './notReferencedByTemplate.css'` but I'll open a separate issue for that.