### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    groups:
+      # Non-major version bumps hopefully shouldn't break anything,
+      # so let's group them together into a single PR!
+      theoretically-non-breaking:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Run once a month, grouping non-major version changes into a single PR, as they are theoretically non-breaking changes.